### PR TITLE
Update vrpn_Tracker_NDI_Polaris.C

### DIFF
--- a/vrpn_Tracker_NDI_Polaris.C
+++ b/vrpn_Tracker_NDI_Polaris.C
@@ -320,11 +320,22 @@ float vrpn_Tracker_NDI_Polaris::parse6CharFloatFromNDIResponse(unsigned char* st
 // The caller passes in the string, and a pointer to an (int) index into that string (which will be advanced
 // to the end of the value we just parsed.
 // The caller must make sure the string is at least seven characters long
-float vrpn_Tracker_NDI_Polaris::parse7CharFloatFromNDIResponse(unsigned char* str,  int* strIndexPtr) {
-	int intVal;
-	sscanf((char*) &(str[*strIndexPtr]),"%7d",&intVal);
-	*strIndexPtr+=7;
-    return (intVal/100.0f); 
+
+// ORIGINAL parse7CharFloatFromNDIResponse function
+//float vrpn_Tracker_NDI_Polaris::parse7CharFloatFromNDIResponse(unsigned char* str,  int* strIndexPtr) {
+//	int intVal;
+//	sscanf((char*) &(str[*strIndexPtr]),"%7d",&intVal);
+//	*strIndexPtr+=7;
+//    return (intVal/100.0f); 
+//}
+
+//using namespace std;
+// NDI parse7CharFloatFromNDIResponse function
+float vrpn_Tracker_NDI_Polaris::parse7CharFloatFromNDIResponse(string str,  int strIndexPtr) {
+	std::string str2 = str.substr (10,17);
+	float intVal = std::stof(str2);
+	strIndexPtr+=7;
+	return (intVal/100.0f);
 }
 
 int vrpn_Tracker_NDI_Polaris::setupOneTool(const char* NDIToolRomFilename)


### PR DESCRIPTION
I'm hoping this patch from our contact at NDI will fix the tracking of rigid bodies when using VRPN with the NDI Polaris Spectra device. I've included his comments below.
_Original file:_ [simple_vrpn.cpp.txt](https://github.com/EvanKrueger/vrpn/files/581934/simple_vrpn.cpp.txt)

>One thing I did notice is that the 'IRATE 0' command is used in 'vrpn_Tracker_NDI_Polaris.C' 
>The IRATE command is deprecated for the SET command. The default illuminator rate is 20 Hz, so to set the illuminators to 60Hz the command should be: 
> `SET PS-0.Param.Illuminator Rate=2`
> 
> I also found the parsing function  'parse7CharFloatFromNDIResponse' returned the incorrect values. Looks like it was due to data type conversion, but in any case I wrote a simple file with some modifications. With these modifications I got better results. I have not been able to test it fully, or add it into the VRPN project as of yet. I've attached the project files, let me know if you can run it with better results. 
>
>Regards,
>Ryan